### PR TITLE
Add new educational learning resources to Auditors Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ PDF: [Smart_Contract_Auditor_PDF.pdf](https://github.com/razzorsec/AuditorsRoadm
 * [Damn Vulnerable DeFi (After Completing Step 11)](https://www.damnvulnerabledefi.xyz/)
 * [RareSkills Puzzles](https://github.com/rareSkills/solidity-riddles)
 * [MiloTruck CTF Challenges](https://github.com/MiloTruck/evm-ctf-challenges/tree/main)
-* 
   
 #### 11) DeFi Deep Dive
 

--- a/README.md
+++ b/README.md
@@ -2,90 +2,131 @@
 
 ![Smart_Contract_Auditor_RoadMap](https://github.com/razzorsec/AuditorsRoadmap/assets/54918791/8ca631ff-dfab-4860-93cb-97718078a5ac)
 
-
 Available at: [Ethereum Smart Contract Auditor Roadmap](https://coggle.it/diagram/YqLzaiSABzXD4UnZ/t/smart-contract-auditor/31d7095363a3896aa0cec56fe62ab51d8bff1a5eae7c2e9ff1be6a1fc8232ef8)  
 
 PDF: [Smart_Contract_Auditor_PDF.pdf](https://github.com/razzorsec/AuditorsRoadmap/files/12446531/Smart_Contract_Auditor_PDF.pdf)
 
-### Step by Step Approach  
+### Step-by-Step Approach
+
 #### 1) Blockchain Fundamentals
+
 * [Mastering Ethereum](https://github.com/ethereumbook/ethereumbook)  
 * Proof of Work vs. Proof of Stake
 * [The Eth2 Book](https://eth2book.info/)
+
 #### 2) Solidity Fundamentals
+
 * [Solidity Documentation](https://docs.soliditylang.org/en/latest/)
 * [Solidity Docs](https://docs.soliditylang.org/en/v0.8.21/index.html)
 * [Smart Contract Programmer - Solidity 0.8](https://www.youtube.com/playlist?list=PLO5VPQH6OWdVQwpQfw9rZ67O6Pjfo6q-p)
 * [Secureum Solidity 101](https://secureum.substack.com/p/solidity-101?s=r)
 * [Secureum Solidity 201](https://secureum.substack.com/p/solidity-201?s=r)
+
 #### 3) Gas Optimizations
+
 * [Aggregated Tricks by pcaversaccio and Harikrishnan Mulackal](https://forum.openzeppelin.com/t/a-collection-of-gas-optimisation-tricks/19966/6)
 * [Kaden: Gas Optimization Tips](https://betterprogramming.pub/how-to-write-smart-contracts-that-optimize-gas-spent-on-ethereum-30b5e9c5db85)
 * [Juan: Advanced Gas Optimizations](https://dev.to/juanxavier/advanced-gas-optimizations-tips-for-solidity-1j2f)
+  
 #### 4) Smart Contract Testing/Debugging
+
 * [Hardhat Docs](https://hardhat.org/guides/waffle-testing.html)
 * [Rodrigo Herrera Itie](https://dev.to/rodrigoherrerai/the-complete-hands-on-hardhat-tutorial-3kbd)
 * [Code Eater - Hindi](https://www.youtube.com/watch?v=vuqhHOx6188&list=PLgPmWS2dQHW9mucRpDVe16j9Qn74ZXqcD&index=5)
 * [Foundry](https://github.com/foundry-rs/foundry)
 * [Tenderly](https://tenderly.co/)
+  
 #### 5) ERC Standards
+
 * [Token Standards - ERC 20, 721, 777, 1155, 4626](https://ethereum.org/en/developers/docs/standards/tokens/)
 * Other Standards: [ERC2981](https://eips.ethereum.org/EIPS/eip-2981)
+  
 #### 6) [Openzeppelin Helper Libraries/Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts)
+
 #### 7) Upgradeable Contracts
+
 * [Smart Contract Programmer - Upgradeable Contracts](https://www.youtube.com/watch?v=JgSj7IiE4jA&t=157s)
 * [Smart Contract Programmer - Risks of Upgradeable Contracts](https://www.youtube.com/watch?v=XmxfB5JOt1Q&t=3s)
 * [Different Proxy Patterns - EIPs 897, 1822, 1967, 1538, 2535](https://ethereum-blockchain-developer.com/110-upgrade-smart-contracts/00-project/)
+  
 #### 8) Smart Contract Attack Vectors
+
 * [Secureum Security Pitfalls 101](https://secureum.substack.com/p/security-pitfalls-and-best-practices-101?s=r)
 * [Secureum Security Pitfalls 201](https://secureum.substack.com/p/security-pitfalls-and-best-practices-201?s=r)
 * [SWC Registry](https://swcregistry.io/)
 * [Smart Contract Programmer - Hack Solidity](https://www.youtube.com/watch?v=4Mm3BCyHtDY&list=PLO5VPQH6OWdWsCgXJT9UuzgbC8SPvTRi5)
 * [Kaden: Smart Contract Attack Vectors](https://github.com/KadenZipfel/smart-contract-attack-vectors)
+  
 #### 9) Yul
+
 * [Inline Assembly](https://docs.soliditylang.org/en/latest/assembly.html)
 * [OPCODES](https://www.evm.codes/)
 * [PRECOMPILES](https://www.evm.codes/precompiled)
 * [Dynamic Gas Costs & Memory Expansion](https://github.com/wolflo/evm-opcodes/blob/main/gas.md)
+  
 #### 10) CTFs
+
 * [CTFs & WriteUps - A curated list (for reference)](https://github.com/blockthreat/blocksec-ctfs)
 * [Ethernaut](https://ethernaut.openzeppelin.com/)
 * [Capture The Ether](https://capturetheether.com/)
 * [CipherShastra](https://ciphershastra.com/)
 * [Damn Vulnerable DeFi (After Completing Step 11)](https://www.damnvulnerabledefi.xyz/)
+  
 #### 11) DeFi Deep Dive
+
 * [Finematics - DeFi](https://www.youtube.com/watch?v=pWGLtjG-F5c&list=PLjrTIwaNiTwn39tg3sR_bPBWGHoznv47D)
 * [DeFi MOOC](https://www.youtube.com/playlist?list=PLS01nW3RtgopJOtsMVOK3N7n7qyNMPbJ_)
 * [Smart Contract Programmer - DeFi](https://www.youtube.com/watch?v=qB2Ulx201wY&list=PLO5VPQH6OWdX-Rh7RonjZhOd9pb9zOnHW)
 * Protocol Deep Dives: Uniswap v2/v3/v4, Compound, Curve, Aave, Balancer, Gearbox
 * [Stablecoins](https://blog.chain.link/what-are-stablecoins/) => [Algorithmic Stablecoins](https://cointelegraph.com/altcoins-for-beginners/a-beginner-s-guide-on-algorithmic-stablecoins)
 * Staking Rewards, Vaults
+  
 #### 12) DeFi Attack Vectors
+
 * Flash Loan => Price Oracle Manipulation
 * Front-Running => Sandwich attacks
 * Rug Pulls => Unlimited Token Allowance
-#### 13) Postmortems & BugFixes
+  
+#### 13) Postmortems & Bug Fixes
+
 * [Immunefi](https://medium.com/@immunefi)
 * [BlockSec](https://blocksecteam.medium.com/)
 * [SlowMist](https://slowmist.medium.com/)
 * [Rekt News](https://rekt.news/)
 * [PeckShield](https://twitter.com/peckshield)
+* [Certik Blog](https://www.certik.com/resources/blog)
+
 #### 14) Report Reading
+
 * [Secureum Audit Findings 101](https://secureum.substack.com/p/audit-findings-101?s=r)
 * [Secureum Audit Findings 201](https://secureum.substack.com/p/audit-findings-201?s=r)
-* [Consensys](https://consensys.io/diligence/audits/), [Trail of Bits](https://github.com/trailofbits/publications#ethereumevm), [Openzeppelin](https://blog.openzeppelin.com/tag/security-audits), [Code4rena](https://code4rena.com/reports), [Sherlock](https://audits.sherlock.xyz/contests), [QuillAudits](https://www.quillaudits.com/leaderboard)
+* [Consensys](https://consensys.io/diligence/audits/)
+* [Trail of Bits](https://github.com/trailofbits/publications#ethereumevm)
+* [Openzeppelin](https://blog.openzeppelin.com/tag/security-audits)
+* [Code4rena](https://code4rena.com/reports)
+* [Sherlock](https://audits.sherlock.xyz/contests)
+* [QuillAudits](https://www.quillaudits.com/leaderboard)
+* [Cyfrin Audits](https://github.com/Cyfrin/cyfrin-audit-reports)
+* [Nethermind Security](https://github.com/NethermindEth/PublicAuditReports)
 * Database: [Solodit](https://solodit.xyz/)
+
 #### 15) Security Standards & Checklists
+
 * [SCSVS](https://github.com/securing/SCSVS)
 * [Rari-Capital Solcurity](https://github.com/Rari-Capital/solcurity)
+  
 #### 16) [Important Ethereum Improvement Proposals (EIPs)](https://eips.ethereum.org/)
+
 * [Core: ](https://eips.ethereum.org/core) 150, 1559, 2929, 2930, 3198, 3529, 3675, 4399, 1153, 4758
 * [Interface](https://eips.ethereum.org/interface): 712
 * [ERC:](https://eips.ethereum.org/erc) 165, 1167, 1271, 2535, 2612, 2771, 2981, 4337, 4626
 * [Meta:](https://eips.ethereum.org/meta) All
+  
 #### 17) Arsenal
+
 * [Remix](https://remix.ethereum.org/)
 * [VS Code IDE](https://code.visualstudio.com/)
+* [Olympix Web3 Cybersecurity Assistant](https://marketplace.visualstudio.com/items?itemName=Olympixai.olympix)
 * [Slither](https://github.com/crytic/slither)
 * [Mythril](https://github.com/ConsenSys/mythril)
 * [Mythx](https://mythx.io/)
@@ -95,11 +136,13 @@ PDF: [Smart_Contract_Auditor_PDF.pdf](https://github.com/razzorsec/AuditorsRoadm
 * [Scribble](https://github.com/ConsenSys/scribble)
 * [BlockSec ETH/BSC Tx Analysis](https://versatile.blocksecteam.com/tx)
 * [ethtx ETH Tx Analysis](https://ethtx.info/)
+  
 #### 18) Continuous Learning and Research
+
 * [Ethereum Magicians](https://ethereum-magicians.org/)
 * [Ethereum Yellow Paper](https://github.com/ethereum/yellowpaper)
 * [Eth Research](https://ethresear.ch/)
-* Newsletters: [Blockthreat](https://newsletter.blockthreat.io/)
+* Newsletters:[Blockthreat](https://newsletter.blockthreat.io/)
 * [Ethereum Execution Specs](https://ethereum.github.io/execution-specs/)
 * [Ethereum Consensus Specs](https://github.com/ethereum/consensus-specs)
 * Join Security Communities on Discord: Immunefi, Secureum, [Blockchain Pentesting](https://discord.gg/JTkeNXX), Eth Security, Eth R&D

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ PDF: [Smart_Contract_Auditor_PDF.pdf](https://github.com/razzorsec/AuditorsRoadm
 * [Capture The Ether](https://capturetheether.com/)
 * [CipherShastra](https://ciphershastra.com/)
 * [Damn Vulnerable DeFi (After Completing Step 11)](https://www.damnvulnerabledefi.xyz/)
+* [RareSkills Puzzles](https://github.com/rareSkills/solidity-riddles)
+* [MiloTruck CTF Challenges](https://github.com/MiloTruck/evm-ctf-challenges/tree/main)
+* 
   
 #### 11) DeFi Deep Dive
 


### PR DESCRIPTION
-  Add Certik blogs in the 'Reading' list.

- Add Cyfrin Audits and Nethermind Security audit reports in the 'Audit Reports' list.

- Add RareSkills Puzzles and MiloTruck CTF Challenges in the 'CTFs' list.

- Add Olympix Web3 Cybersecurity Assistant VS Code Marketplace extension in the 'Tools' list.

- Fixed some space issues.